### PR TITLE
feat: support svg images

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ rand = "0.8.5"
 display-info = "0.5.1"
 egui-notify = "0.17.0"
 svg_metadata = "0.5.1"
+textwrap = "0.16.1"
 
 [profile.dev.package."*"]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ clap = {version = "4.5.20", features = ["derive"]}
 rand = "0.8.5"
 display-info = "0.5.1"
 egui-notify = "0.17.0"
+svg_metadata = "0.5.1"
 
 [profile.dev.package."*"]
 opt-level = 3

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use cirrus_theming::Theme;
-use eframe::egui::{self, Color32, CursorIcon, ImageSource, Margin, Rect, Stroke, Vec2};
+use eframe::egui::{self, Color32, CursorIcon, ImageSource, Margin, Rect, Vec2};
 use egui_notify::Toasts;
 
 use crate::{error, files, image::{apply_image_optimizations, Image}, info_box::InfoBox, window_scaling::WindowScaling, zoom_pan::ZoomPan};

--- a/src/app.rs
+++ b/src/app.rs
@@ -91,7 +91,7 @@ impl eframe::App for Roseate {
                                         self.info_box = InfoBox::new(Some(image.clone()), self.theme.clone());
                                     },
                                     Err(error) => {
-                                        error::log_and_toast(error, &mut self.toasts)
+                                        error::log_and_toast(error.into(), &mut self.toasts)
                                             .duration(Some(Duration::from_secs(5)));
                                     },
                                 }
@@ -112,7 +112,12 @@ impl eframe::App for Roseate {
                 let mut optimizations = Vec::new();
                 optimizations = apply_image_optimizations(optimizations, &mutable_image.image_size);
 
-                mutable_image.load_image(&optimizations);
+                let result = mutable_image.load_image(&optimizations);
+
+                if let Err(error) = result {
+                    error::log_and_toast(error.into(), &mut self.toasts)
+                        .duration(Some(Duration::from_secs(10)));
+                }
 
                 self.image_loaded = true;
             }

--- a/src/app.rs
+++ b/src/app.rs
@@ -64,7 +64,6 @@ impl eframe::App for Roseate {
                     let rose_width: f32 = 130.0;
 
                     egui::Frame::default()
-                        .stroke(Stroke::default())
                         .outer_margin(
                             // I adjust the margin as it's the only way I know to 
                             // narrow down the interactive part (clickable part) of the rose image.

--- a/src/files.rs
+++ b/src/files.rs
@@ -5,7 +5,7 @@ use crate::image::Image;
 
 pub fn select_image() -> Result<Image, Error> {
     let image_path = FileDialog::new()
-        .add_filter("images", &["png", "jpeg", "jpg", "webp", "gif"])
+        .add_filter("images", &["png", "jpeg", "jpg", "webp", "gif", "svg"])
         .pick_file();
 
     let image_or_error = match image_path {

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use std::{env, path::Path, time::Duration};
 
 use log::debug;
 use eframe::egui;
-use egui_notify::Toasts;
+use egui_notify::{ToastLevel, Toasts};
 use cirrus_theming::Theme;
 use clap::{arg, command, Parser};
 
@@ -67,11 +67,20 @@ fn main() -> eframe::Result {
             if !path.exists() {
                 let error = Error::FileNotFound(path.to_path_buf());
 
-                log_and_toast(error, &mut toasts)
+                log_and_toast(error.into(), &mut toasts)
                     .duration(Some(Duration::from_secs(10)));
 
                 None
             } else {
+                // Our svg implementation is very experimental. Let's warn the user.
+                if path.extension().unwrap_or_default() == "svg" {
+                    log_and_toast(
+                        "SVG files are experimental! \
+                            Expect many bugs, inconstancies and performance issues.".into(),
+                        &mut toasts
+                    ).level(ToastLevel::Warning).duration(Some(Duration::from_secs(8)));
+                }
+
                 Some(Image::from_path(path))
             }
         },


### PR DESCRIPTION
It seems that svg_metadata just converts percentages into numbers. `50%` would just return `50`.

![image](https://github.com/user-attachments/assets/5f585b9d-b12f-4b7b-ac7d-53ad895923d8)
