### PR TITLE
fix: buttons in magnification panel for light mode

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use cirrus_theming::v1::Theme;
+use cirrus_theming::v1::{Colour, Theme};
 use eframe::egui::{self, Align, Color32, Context, CursorIcon, Frame, ImageSource, Layout, Margin, Rect, Shadow, Stroke, Style, TextStyle, Vec2};
 use egui_notify::ToastLevel;
 
@@ -96,10 +96,18 @@ impl Roseate {
 
     fn draw_dotted_line(&self, ui: &egui::Painter, pos: &[egui::Pos2]) {
         ui.add(
-            egui::Shape::dashed_line(pos, Stroke {
-                width: 2.0,
-                color: Color32::from_hex(&self.theme.accent_colour.hex_code).unwrap()
-            }, 10.0, 10.0)
+            egui::Shape::dashed_line(
+                pos, 
+                Stroke {
+                    width: 2.0,
+                    color: Color32::from_hex(
+                        &self.theme.accent_colour.as_ref()
+                            .unwrap_or(&Colour {hex_code: "e05f78".into()}).hex_code
+                    ).unwrap()
+                },
+                10.0, 
+                10.0
+            )
         );
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -76,6 +76,11 @@ impl Roseate {
         );
         custom_style.visuals.window_shadow = Shadow::NONE;
 
+        custom_style.visuals.widgets.inactive.bg_fill =
+            Color32::from_hex(
+                &self.theme.primary_colour.hex_code
+            ).unwrap();
+
         // Text styling.
         custom_style.visuals.override_text_color = Some(
             Color32::from_hex(

--- a/src/magnification_panel.rs
+++ b/src/magnification_panel.rs
@@ -54,6 +54,7 @@ impl MagnificationPanel {
                     .spacing([10.0, 10.0])
                     .num_columns(2)
                     .show(ui, |ui| {
+                        let style = ctx.style().visuals.widgets.inactive;
                         let button_size = Vec2::new(20.0, 30.0);
 
                         ui.centered_and_justified(|ui| {
@@ -61,6 +62,7 @@ impl MagnificationPanel {
                                 ui.add(
                                     egui::Button::new("+")
                                     .min_size(button_size)
+                                    .fill(style.bg_fill)
                                 );
 
                             if zoom_in.clicked() {
@@ -74,6 +76,7 @@ impl MagnificationPanel {
                                 ui.add(
                                     egui::Button::new("-")
                                     .min_size(button_size)
+                                    .fill(style.bg_fill)
                                 );
 
                             if zoom_out.clicked() {


### PR DESCRIPTION
> [!NOTE]
> This also changes the color for dark mode.

It seems that the buttons in that `Window` don't use roseate's theme settings. <img width="60px" src="https://github.com/user-attachments/assets/cb5172df-700c-4870-8dff-1fc0d4484f47">